### PR TITLE
aoc2018 day4 refactoring

### DIFF
--- a/src/aoc2018/day4.clj
+++ b/src/aoc2018/day4.clj
@@ -24,16 +24,16 @@
        (map parse-one-log)))
 
 (defn is-begins-shift-log? [log]
-  (->> log
-       :guard-id
-       some?))
+  (-> log
+      :guard-id
+      some?))
 
 (defn get-last-guard-id
   "교대 근무 로그만 연속으로 모여 있을 경우 마지막 근무 가드의 id만 가져옴"
   [begins-shift-logs]
-  (->> begins-shift-logs
-       last
-       :guard-id))
+  (-> begins-shift-logs
+      last
+      :guard-id))
 
 (defn separate-log-to-guards-actions
   "파싱된 로그들을 입력받아 가드마다의 액션 타임(분)을 집계
@@ -55,9 +55,9 @@
                :actions actions}))))
 
 (comment
-  (->> input-file
-       parse-input-logs
-       separate-log-to-guards-actions))
+  (-> input-file
+      parse-input-logs
+      separate-log-to-guards-actions))
 
 (defn get-total-asleep-times [{:keys [actions]}]
   (->> actions
@@ -93,8 +93,8 @@
        separate-log-to-guards-actions
        find-most-asleep-guard-actions
        get-most-asleep-minute-portion-with-guard-id
-       ((fn [{:keys [guard-id minute]}]
-          (* guard-id minute)))))
+       ((juxt :guard-id :minute))
+       (apply *)))
 
 ; Part 2
 (defn find-most-frequently-asleep-same-minute [guard-id->action-minutes]
@@ -106,5 +106,5 @@
   (->> (parse-input-logs input-file)
        separate-log-to-guards-actions
        find-most-frequently-asleep-same-minute
-       ((fn [{:keys [minute guard-id]}]
-          (* minute guard-id)))))
+       ((juxt :guard-id :minute))
+       (apply *)))

--- a/src/aoc2018/day4.clj
+++ b/src/aoc2018/day4.clj
@@ -1,140 +1,121 @@
 (ns aoc2018.day4
   "https://adventofcode.com/2018/day/4"
-  (:require [util.file :as file]
-            [clojure.edn :as edn])
-  (:import (java.time Duration LocalDateTime)
-           (java.time.format DateTimeFormatter)))
-
-(def log-date-time-format (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm"))
-
-(defn parse-to-local-date-time [date-time-str]
-  (LocalDateTime/parse date-time-str log-date-time-format))
-
-(defn get-minutes [local-date-time]
-  (.getMinute local-date-time))
-
-(defn get-minute-part-after-interval [start-date-time interval-minutes]
-  (->> (.plusMinutes start-date-time interval-minutes)
-       get-minutes))
-
-(defn get-duration-as-minutes [start-date-time end-date-time]
-  (->> (Duration/between start-date-time end-date-time)
-       .toMinutes))
-
-(defn get-duration-minutes-seq [start-date-time end-date-time]
-  (->> (get-duration-as-minutes start-date-time end-date-time)
-       range
-       (map (partial get-minute-part-after-interval start-date-time))))
-
-(defn get-duration-minute-frequencies [start-date-time end-date-time]
-  (->> (get-duration-minutes-seq start-date-time end-date-time)
-       frequencies))
-
-{:year  2020
- :month 4}
-
-
-
-(comment
-  (parse-to-local-date-time "1518-05-11 00:58")
-  (def mock-date-time (parse-to-local-date-time "1518-05-11 00:58"))
-  (def mock-date-time2 (parse-to-local-date-time "1518-05-11 03:58"))
-  (.toMinutes (Duration/between  (parse-to-local-date-time "1518-05-11 00:58")  (parse-to-local-date-time "1518-05-11 02:59")))
-  (get-duration-as-minutes (parse-to-local-date-time "1518-05-11 00:58")
-                           (parse-to-local-date-time "1518-05-11 03:58"))
-  (get-minute-part-after-interval mock-date-time 3)
-  (get-duration-minutes-seq mock-date-time mock-date-time2)
-  (get-duration-minute-frequencies mock-date-time mock-date-time2)
-  (.plusMinutes (parse-to-local-date-time "1518-05-11 03:58") 1)
-  (->> (parse-to-local-date-time "1518-05-11 00:58")
-       get-minutes))
+  (:require [util.file :as file]))
 
 (def input-file "aoc2018/day4_in.txt")
-(def input (file/read-file input-file))
 
-(defn parse-one-line-to-hash-map [line]
+(defn parse-int [s]
+  (if s (Integer/parseInt s) nil))
+
+(defn parse-one-log
+  "로그를 파싱해 문제에 필요한 요소인 가드 id와 액션이 일어난 분만 캐치함"
+  [line]
   (->> line
-       (re-find #"\[(.+)\][^0-9]*(\d+)?")
+       (re-find #".*:(\d+)[^0-9]*(\d+)?")
        (drop 1)
-       ((fn [[date-time guard-id]]
-          {:local-date-time (parse-to-local-date-time date-time)
-           :guard-id (edn/read-string guard-id)}))))
+       (map parse-int)
+       ((fn [[minute guard-id]]
+          {:minute minute
+           :guard-id guard-id}))))
 
-(defn parse-input-log [file-name]
+(defn parse-input-logs [file-name]
   (->> (file/read-file file-name)
-       (map parse-one-line-to-hash-map)))
-
-(defn get-date-time-sorted-logs [logs]
-  (sort-by :local-date-time logs))
+       sort
+       (map parse-one-log)))
 
 (defn is-begins-shift-log? [log]
   (->> log
        :guard-id
        some?))
-for
-(defn separate-begin-log [date-time-sorted-logs]
-  (->> date-time-sorted-logs
+
+(defn get-last-guard-id
+  "교대 근무 로그만 연속으로 모여 있을 경우 마지막 근무 가드의 id만 가져옴"
+  [begins-shift-logs]
+  (->> begins-shift-logs
+       last
+       :guard-id))
+
+(defn separate-log-to-guards-actions
+  "파싱된 로그들을 입력받아 가드마다의 액션 타임(분)을 집계
+  포맷: {:guard-id guard-id
+        :actions (asleep awake asleep awake ...)}
+  ex) [{:guard-id 877
+        :actions (6 25 38 51 ...)},
+       {:guard-id 1021
+        :actions (15 34 37 44 ...)}, ...]"
+  [logs]
+  (->> logs
        (partition-by is-begins-shift-log?)
-       (apply hash-map)))
-
-(defn get-asleep-minutes-seq [action-logs]
-  (->> action-logs
        (partition 2)
-       (map (fn [[{fall-asleep-time :local-date-time}
-                  {wake-up-time :local-date-time}]]
-              (get-duration-minutes-seq fall-asleep-time wake-up-time)))
-       (reduce concat)))
-
-(defn get-total-asleep-times [action-logs]
-  (->> action-logs
-       (partition 2)
-       (map (fn [[{fall-asleep-time :local-date-time}
-                  {wake-up-time :local-date-time}]]
-              (get-duration-as-minutes fall-asleep-time wake-up-time)))
-       (reduce +)))
-
-(defn aggregate-guard-asleep-times [separate-begin-log]
-  (->> separate-begin-log
-       (map (fn [[[begin-log] action-logs]]
-              {(:guard-id begin-log) (get-total-asleep-times action-logs)}))
-       (apply merge-with +)))
-
-
-(defn aggregate-guard-asleep-minutes [separate-begin-log]
-  (->> separate-begin-log
-       (map (fn [[[begin-log] action-logs]]
-              {(:guard-id begin-log) (get-asleep-minutes-seq action-logs)}))
-       (apply merge-with concat)))
-
-
-(defn find-most-asleep-guard-id [guard-asleep-times]
-  (->> guard-asleep-times
-       (apply max-key val)
-       key))
-
-(defn get-asleep-minutes-frequencies-certain-guard [guard-id guard-asleep-minutes]
-  (->> (get guard-asleep-minutes guard-id)
-       frequencies))
-
-
+       (map (fn [[begins-shift-logs actions]]
+              {(get-last-guard-id begins-shift-logs) (map :minute actions)}))
+       (apply merge-with concat)
+       (map (fn [[guard-id actions]]
+              {:guard-id guard-id
+               :actions actions}))))
 
 (comment
-  (parse-one-line-to-hash-map "[1518-05-11 00:58] wakes up")
-  (parse-one-line-to-hash-map "[1518-08-17 00:01] Guard #1021 begins shift")
-  (def parsed-input (parse-input-log input-file))
-  (def sorted-logs (get-date-time-sorted-logs parsed-input))
-  (separate-begin-log sorted-logs)
-  (aggregate-guard-asleep-times (separate-begin-log sorted-logs))
-  (def most-asleap-guard-id (->> sorted-logs
-                                 separate-begin-log
-                                 aggregate-guard-asleep-times
-                                 find-most-asleep-guard-id))
-  (frequencies (get (->> sorted-logs
-                         separate-begin-log
-                         aggregate-guard-asleep-minutes) 571))
-  (->> sorted-logs
-       separate-begin-log
-       aggregate-guard-asleep-minutes
-       (get-asleep-minutes-frequencies-certain-guard most-asleap-guard-id)
+  (->> input-file
+       parse-input-logs
+       separate-log-to-guards-actions))
+
+(defn get-total-asleep-times [actions]
+  (->> actions
+       (partition 2)
+       (map #(- (second %) (first %)))
+       (reduce +)))
+
+(defn get-asleep-minutes-frequencies [actions]
+  (->> actions
+       (partition 2)
+       (map #(range (first %) (second %)))
+       (reduce concat)
+       frequencies))
+
+(defn get-most-asleep-minute-portion
+  "액션들을 입력받아 가장 많이 잤던 분을 찾아 빈도수와 함께 리턴
+  ex) {:minute 30
+       :freq 5}"
+  [actions]
+  (->> actions
+       get-asleep-minutes-frequencies
        (apply max-key val)
-       key))
+       ((fn [[minute freq]]
+          {:minute minute
+           :freq freq}))))
+
+; Part 1
+
+(defn find-most-asleep-guard-actions [guards-actions]
+  (->> guards-actions
+       (apply max-key #(get-total-asleep-times (:actions %)))))
+
+(comment
+  (->> (parse-input-logs input-file)
+       separate-log-to-guards-actions
+       find-most-asleep-guard-actions
+       ((fn [{:keys [guard-id actions]}]
+          (->> actions
+               get-most-asleep-minute-portion
+               :minute
+               (* guard-id))))))
+
+; Part 2
+(defn map-most-asleep-minute-per-guard [guards-actions]
+  (->> guards-actions
+       (map (fn [{:keys [guard-id actions]}]
+              (-> actions
+                  get-most-asleep-minute-portion
+                  (assoc :guard-id guard-id))))))
+
+(defn find-most-frequently-asleep-same-minute [guard-id->action-minutes]
+  (->> guard-id->action-minutes
+       map-most-asleep-minute-per-guard
+       (apply max-key :freq)))
+
+(comment
+  (->> (parse-input-logs input-file)
+       separate-log-to-guards-actions
+       find-most-frequently-asleep-same-minute
+       ((fn [{:keys [minute guard-id]}]
+          (* minute guard-id)))))

--- a/src/aoc2018/day4.clj
+++ b/src/aoc2018/day4.clj
@@ -5,8 +5,9 @@
 (def input-file "aoc2018/day4_in.txt")
 
 (defn parse-int [s]
-  (if s (Integer/parseInt s) nil))
-
+  (when s (Integer/parseInt s)))
+  ;(if s (Integer/parseInt s) nil)
+(parse-int "12")
 (defn parse-one-log
   "로그를 파싱해 문제에 필요한 요소인 가드 id와 액션이 일어난 분만 캐치함"
   [line]
@@ -72,7 +73,7 @@
   [{:keys [guard-id actions]}]
   (->> actions
        (partition 2)
-       (map #(range (first %) (second %)))
+       (map (partial apply range))
        (reduce concat)
        frequencies
        (apply max-key val)

--- a/src/aoc2018/day4.clj
+++ b/src/aoc2018/day4.clj
@@ -65,20 +65,16 @@
        (map #(- (second %) (first %)))
        (reduce +)))
 
-(defn get-asleep-minutes-frequencies [actions]
-  (->> actions
-       (partition 2)
-       (map #(range (first %) (second %)))
-       (reduce concat)
-       frequencies))
-
 (defn get-most-asleep-minute-portion
   "액션들을 입력받아 가장 많이 잤던 분을 찾아 빈도수와 함께 리턴
   ex) {:minute 30
        :freq 5}"
   [actions]
   (->> actions
-       get-asleep-minutes-frequencies
+       (partition 2)
+       (map #(range (first %) (second %)))
+       (reduce concat)
+       frequencies
        (apply max-key val)
        ((fn [[minute freq]]
           {:minute minute

--- a/src/aoc2018/day4.clj
+++ b/src/aoc2018/day4.clj
@@ -18,9 +18,8 @@
           {:minute minute
            :guard-id guard-id}))))
 
-(defn parse-input-logs [file-name]
-  (->> (file/read-file file-name)
-       sort
+(defn parse-input-logs [logs]
+  (->> (sort logs)
        (map parse-one-log)))
 
 (defn is-begins-shift-log? [log]
@@ -55,7 +54,7 @@
                :actions actions}))))
 
 (comment
-  (-> input-file
+  (-> (file/read-file input-file)
       parse-input-logs
       separate-log-to-guards-actions))
 
@@ -77,10 +76,9 @@
        (reduce concat)
        frequencies
        (apply max-key val)
-       ((fn [[minute freq]]
-          {:guard-id guard-id
-           :minute minute
-           :freq freq}))))
+       (#(hash-map :guard-id guard-id
+                   :minute (key %)
+                   :freq (val %)))))
 
 ; Part 1
 
@@ -89,7 +87,8 @@
        (apply max-key get-total-asleep-times)))
 
 (comment
-  (->> (parse-input-logs input-file)
+  (->> (file/read-file input-file)
+       parse-input-logs
        separate-log-to-guards-actions
        find-most-asleep-guard-actions
        get-most-asleep-minute-portion-with-guard-id
@@ -103,7 +102,8 @@
        (apply max-key :freq)))
 
 (comment
-  (->> (parse-input-logs input-file)
+  (->> (file/read-file input-file)
+       parse-input-logs
        separate-log-to-guards-actions
        find-most-frequently-asleep-same-minute
        ((juxt :guard-id :minute))


### PR DESCRIPTION
- 기존의 자바 라이브러리를 이용한 datetime 파싱을 폐기하고, 자정 시간대에만 액션이 일어나는 문제의 조건을 이용해 분(Minute) 정보만 파싱하는 식의 간단한 자료 구조로 개편
- 로직 중심적인 흐름이 아닌 데이터 중심적인 흐름을 구축하기 위해 hash-map을 적극 활용하여 함수와 자료구조들을 개편